### PR TITLE
Make dark theme copy toast text visible

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -630,6 +630,10 @@ h1.page + aside.toc.embedded {
   fill: currentColor;
 }
 
+.dark-theme .doc .source-toolbox .copy-toast {
+  color: var(--color-black);
+}
+
 .doc .source-toolbox .copy-toast {
   flex: none;
   position: relative;


### PR DESCRIPTION
Hi! I saw your site referenced on the Antora Zulip chat, which looks great.
Noticed the "Copied!" text was not yet visible in dark mode.