### PR TITLE
upgrade Asciidoctor Tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MPL-2.0",
       "devDependencies": {
         "@asciidoctor/core": "~2.2",
-        "@asciidoctor/tabs": "1.0.0-alpha.7",
+        "@asciidoctor/tabs": "1.0.0-alpha.8",
         "@fontsource/roboto": "~4.5",
         "@fontsource/roboto-mono": "~4.5",
         "autoprefixer": "~10.4",
@@ -83,9 +83,9 @@
       }
     },
     "node_modules/@asciidoctor/tabs": {
-      "version": "1.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/tabs/-/tabs-1.0.0-alpha.7.tgz",
-      "integrity": "sha512-cN4pjFACV+4bzzOa+lElCCIGxHkT2MWDiNLygUkOUGGsET1lvCJXQjvF3mL0giA2zUnmR5QGZSv93JNj57HF3A==",
+      "version": "1.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/tabs/-/tabs-1.0.0-alpha.8.tgz",
+      "integrity": "sha512-pRlucoViBtkxvQfN/IzK1Remo00fAsobx5fyA4I6VugH6qVK0N86FizIKTXlf8bnoFL/t1K+24NN2ymMDTI1/w==",
       "dev": true,
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "devDependencies": {
     "@asciidoctor/core": "~2.2",
-    "@asciidoctor/tabs": "1.0.0-alpha.7",
+    "@asciidoctor/tabs": "1.0.0-alpha.8",
     "@fontsource/roboto": "~4.5",
     "@fontsource/roboto-mono": "~4.5",
     "autoprefixer": "~10.4",

--- a/src/css/vendor/asciidoctor-tabs.css
+++ b/src/css/vendor/asciidoctor-tabs.css
@@ -13,39 +13,23 @@
   padding-bottom: 0.25rem;
 }
 
-.doc .tabset > .content,
-.doc .tabset .tab-pane {
-  border: 0;
-  padding: 0;
-}
-
 .doc .tabset .tabs {
   font-size: calc(12 / var(--pixel-to-rem));
-  /*
-  margin: 0 0 2px 1px;
-  */
   margin: 0 0 0.25rem;
 }
 
-.doc .tabset .tabs > ul li {
+.doc .tabset .tabs > ul li.tab {
+  background-color: var(--tabs-background-color);
   border: 1px solid var(--tabs-border-color);
+  color: var(--tabs-font-color);
   height: auto;
   line-height: inherit;
   margin: 0;
   padding: 0.3rem 0.6rem;
 }
 
-.doc .tabset:not(.is-loading) .tabs > ul li {
-  transition: background-color 200ms;
-}
-
-.doc .tabset .tabs > ul li:not(.is-active) {
-  background-color: var(--tabs-background-color);
-  color: var(--tabs-font-color);
-}
-
-.doc .tabset.is-loading .tabs li:first-child,
-.doc .tabset .tabs li.is-active {
+.doc .tabset.is-loading .tabs > ul li.tab:first-child,
+.doc .tabset .tabs > ul li.tab.is-active {
   background-color: var(--tabs-selected-background-color);
   border-color: var(--tabs-selected-background-color);
   color: var(--tabs-selected-font-color);
@@ -55,8 +39,12 @@
   content: none;
 }
 
-/*
-.doc .tabset pre > code {
-  border-radius: 0;
+.doc .tabset > .content,
+.doc .tabset .tab-pane {
+  border: 0;
+  padding: 0;
 }
-*/
+
+html.theme-set .doc .tabset .tabs > ul li {
+  transition: background-color 200ms ease-in-out, color 100ms linear;
+}

--- a/src/js/vendor/switchtheme.js
+++ b/src/js/vendor/switchtheme.js
@@ -25,6 +25,9 @@
 
   function swithInitialTheme () {
     if (isInitialThemeDark()) htmlElement.classList.add('dark-theme')
+    window.requestAnimationFrame(function () {
+      htmlElement.classList.add('theme-set')
+    })
   }
 
   function onWindowLoad () {


### PR DESCRIPTION
- upgrade @asciidoctor/tabs to 1.0.0-alpha.8; adds support for position lock on sync and sync on fragment change
- add theme-set class to HTML element once theme is set
- defer transition on tabs until theme is set
- consolidate tabs styles and remove unused styles