### PR TITLE
fix guard in asciidocExtensionRegistered helper

### DIFF
--- a/src/helpers/asciidocExtensionRegistered.js
+++ b/src/helpers/asciidocExtensionRegistered.js
@@ -2,7 +2,7 @@
 
 module.exports = (requireRequest, { data }) => {
   const { componentVersion } = data.root.page
-  if (!componentVersion || !componentVersion.asciidoc || !componentVersion.extensions) return
+  if (!componentVersion || !componentVersion.asciidoc || !componentVersion.asciidoc.extensions) return
   const cache = data.extensionCache || (data.extensionCache = {})
   let extension
   if (requireRequest in cache) {


### PR DESCRIPTION
Missing the asciidoc property when checking for extensions.