### PR TITLE
don't attempt to style inline code phrase inside code block

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -565,7 +565,7 @@ h1.page + aside.toc.embedded {
   white-space: pre-wrap;
 }
 
-.doc pre.highlight code,
+.doc pre.highlight code.hljs,
 .doc .listingblock pre:not(.highlight),
 .doc .literalblock pre {
   background: var(--pre-background);
@@ -575,7 +575,7 @@ h1.page + aside.toc.embedded {
   padding: 0.75rem;
 }
 
-.doc pre code[data-lang]::before {
+.doc pre > code[data-lang]::before {
   color: var(--pre-annotation-font-color);
 }
 

--- a/src/css/spring/asciidoctor.css
+++ b/src/css/spring/asciidoctor.css
@@ -232,7 +232,7 @@
   margin: 0;
 }
 
-.doc pre.highlight code,
+.doc pre.highlight code.hljs,
 .doc .listingblock pre:not(.highlight),
 .doc .literalblock pre {
   background: var(--asciidoctor-pre-background);


### PR DESCRIPTION
- only apply block-level styles to code tag with hljs class

This addresses issue if a code span happens to end up inside a code block.