### PR TITLE
show any version in nav explore when using a local/offline branch build

### DIFF
--- a/src/partials/nav-explore.hbs
+++ b/src/partials/nav-explore.hbs
@@ -11,7 +11,7 @@
       <a class="title" href="{{{relativize ./url}}}">{{{./title}}}</a>
       <ul class="versions">
         {{#each ./versions}}
-        {{#if ./versionSegment}}
+        {{#if (or ./versionSegment (not @root.site.url))}}
         <li class="version
           {{~#if (and (eq .. @root.page.component) (eq this @root.page.componentVersion))}} is-current{{/if~}}
           {{~#if (eq this ../latest)}} is-latest{{/if}}">


### PR DESCRIPTION
If the site URL is not set, assume we should show the version in the nav explore panel (as it will likely not be a version that is normally shown).