### PR TITLE
fix metadata so search filter works in UI preview

### DIFF
--- a/preview-src/5.5/index.adoc.yml
+++ b/preview-src/5.5/index.adoc.yml
@@ -1,12 +1,13 @@
 url: /5.5/index.html
 component:
   name: security
-version: '5.5'
+version: '5.5.9'
 latest:
   url: '/index.html'
-  version: '5.6'
-  displayVersion: '5.6'
+  version: '5.6.10'
+  displayVersion: '5.6.10'
   title: 'Spring Security'
+  versionSegment: '5.6'
 previous:
   content: Quickstart
   url: '#'

--- a/preview-src/features/authentication/index.adoc.yml
+++ b/preview-src/features/authentication/index.adoc.yml
@@ -1,11 +1,11 @@
 url: /features/authentication/index.html
 component:
   name: security
-version: '5.6'
+version: '5.6.10'
 latest:
   url: '/features/authentication/index.html'
-  version: '5.6'
-  displayVersion: '5.6'
+  version: '5.6.10'
+  displayVersion: '5.6.10'
   title: Spring Security
 previous:
   content: Quickstart

--- a/preview-src/features/exploits/index.adoc.yml
+++ b/preview-src/features/exploits/index.adoc.yml
@@ -1,11 +1,11 @@
 url: /features/exploits/index.html
 component:
   name: security
-version: '5.6'
+version: '5.6.10'
 latest:
   url: '/features/exploits/index.html'
-  version: '5.6'
-  displayVersion: '5.6'
+  version: '5.6.10'
+  displayVersion: '5.6.10'
   title: Spring Security
 previous:
   content: Quickstart

--- a/preview-src/features/index.adoc.yml
+++ b/preview-src/features/index.adoc.yml
@@ -2,11 +2,11 @@ url: /features/index.html
 component:
   name: security
   url: '#'
-version: '5.6'
+version: '5.6.10'
 latest:
   url: '/features/index.html'
-  version: '5.6'
-  displayVersion: '5.6'
+  version: '5.6.10'
+  displayVersion: '5.6.10'
   title: Spring Security
 previous:
   content: Quickstart

--- a/preview-src/index.adoc.yml
+++ b/preview-src/index.adoc.yml
@@ -1,7 +1,7 @@
 url: /index.html
 component:
   name: security
-version: '5.6'
+version: '5.6.10'
 latest:
   url: '/index.html'
 previous:

--- a/preview-src/session/index.adoc.yml
+++ b/preview-src/session/index.adoc.yml
@@ -1,7 +1,7 @@
 url: /session/index.html
 component:
   name: session
-version: '2.5'
+version: '2.5.9'
 previous:
   content: Quickstart
   url: '#'

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -15,27 +15,30 @@ site:
     versions: &security_versions
     - &security_latest_version
       url: '/index.html'
-      version: '5.6'
-      displayVersion: '5.6'
+      version: '5.6.10'
+      displayVersion: '5.6.10'
       title: *component_title
+      versionSegment: '5.6'
     - &security_5_5_version
       url: '/5.5/index.html'
-      version: '5.5'
-      displayVersion: '5.5'
+      version: '5.5.9'
+      displayVersion: '5.5.9'
+      versionSegment: '5.5'
     latest: *security_latest_version
   - name: session
-    title: &component_title Spring Session
+    title: &session_component_title Spring Session
     url: '#'
     versions:
-      - &latest_version
+      - &session_latest_version
         url: '/session/index.html'
-        version: '2.6'
-        displayVersion: '2.6'
-        title: *component_title
-    latest: *latest_version
+        version: '2.5.9'
+        displayVersion: '2.5.9'
+        title: *session_component_title
+        versionSegment: '2.5'
+    latest: *session_latest_version
 shared:
   security:
-    5.5:
+    5.5.9:
       home: true
       title: Spring Security
       relativeSrcPath: index.adoc
@@ -45,19 +48,23 @@ shared:
         url: '#'
         versions:
           - url: '/index.html'
-            version: '5.6'
-            displayVersion: '5.6'
+            version: '5.6.10'
+            displayVersion: '5.6.10'
             title: *component_title
+            versionSegment: '5.6'
           - url: '/5.5/index.html'
-            version: '5.5'
-            displayVersion: '5.5'
+            version: '5.5.9'
+            displayVersion: '5.5.9'
+            versionSegment: '5.5'
       componentVersion: *security_5_5_version
       versions:
-        - version: '5.6'
-          displayVersion: '5.6'
+        - version: '5.6.10'
+          displayVersion: '5.6.10'
           url: '#'
-        - version: '5.5'
-          displayVersion: '5.5'
+          versionSegment: '5.6'
+        - version: '5.5.9'
+          displayVersion: '5.5.9'
+          versionSegment: '5.5'
           url: '#'
       navigation:
         - root: true
@@ -71,7 +78,7 @@ shared:
                   url: '#'
                 - content: Protection Against Exploits
                   url: '#'
-    5.6:
+    5.6.10:
       home: true
       title: Spring Security
       relativeSrcPath: index.adoc
@@ -82,12 +89,14 @@ shared:
         versions: *security_versions
       componentVersion: *security_latest_version
       versions:
-        - version: '5.6'
-          displayVersion: '5.6'
+        - version: '5.6.10'
+          displayVersion: '5.6.10'
           url: '#'
-        - version: '5.5'
-          displayVersion: '5.5'
+          versionSegment: '5.6'
+        - version: '5.5.9'
+          displayVersion: '5.5.9'
           url: '#'
+          versionSegment: '5.5'
       navigation:
         - root: true
           items:
@@ -101,7 +110,7 @@ shared:
                 - content: Protection Against Exploits
                   url: '/features/exploits/index.html'
   session:
-    2.5:
+    2.5.9:
       home: true
       title: Spring Session
       relativeSrcPath: index.adoc
@@ -110,11 +119,7 @@ shared:
         title: Spring Session
         url: '#'
         versions:
-          - &session_latest_version
-            url: '/session/index.html'
-            version: '2.5'
-            displayVersion: '2.5'
-            title: 'Spring Session'
+          - *session_latest_version
       componentVersion: *session_latest_version
       navigation:
         - root: true


### PR DESCRIPTION
With this change, the search filter will work in the UI preview when the appropriate ALGOLIA_ environment variables are set. The problem before is that the versions were not real, so the search query was not matching anything.

This update also restores the behavior of the nav explore panel on most pages.