### PR TITLE
Update related project text for Spring Pulsar

### DIFF
--- a/src/helpers/related_projects.js
+++ b/src/helpers/related_projects.js
@@ -237,7 +237,7 @@ function relatedProjects (categories = [], projectIds = []) {
     { href: 'https://docs.spring.io/spring-graphql/reference/', id: 'graphql', text: 'Spring GraphQL' },
     { href: 'https://docs.spring.io/spring-kafka/reference/', id: 'kafka', text: 'Spring for Apache Kafka' },
     { href: 'https://docs.spring.io/spring-modulith/reference/', id: 'modulith', text: 'Spring Modulith' },
-    { href: 'https://docs.spring.io/spring-pulsar/reference/', id: 'pulsar', text: 'Spring Pulsar' },
+    { href: 'https://docs.spring.io/spring-pulsar/reference/', id: 'pulsar', text: 'Spring for Apache Pulsar' },
     { href: 'https://docs.spring.io/spring-shell/reference/', id: 'shell', text: 'Spring Shell' },
   ]
   return projectDocumentation.filter(


### PR DESCRIPTION
The current text is 'Spring Pulsar' but instead needs to be 'Spring for Apache Pulsar'.