### PR TITLE
Improve breadcrumb styling

### DIFF
--- a/src/css/spring/spring-doc.css
+++ b/src/css/spring/spring-doc.css
@@ -140,13 +140,7 @@ mark {
 
 .doc > h1#page-title {
   font-size: calc(42 / var(--rem-base) * 1rem);
-  margin: 0.2rem 0;
-}
-
-@media screen and (min-width: 769px) {
-  .doc > h1#page-title {
-    margin-top: 0.2rem;
-  }
+  margin: 0.8rem 0 0.2rem 0;
 }
 
 .doc > h1#page-title + aside.toc.embedded {
@@ -308,4 +302,15 @@ mark {
 
 .admonitionblock.latest {
   padding: 1.5rem 1rem 0;
+}
+
+/* Improve Breadcrumbs */
+
+.breadcrumbs,
+.breadcrumbs a {
+  color: var(--breadcrumb-font-color);
+}
+
+.breadcrumbs a:hover {
+  color: var(--breadcrumb-hover-font-color);
 }

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -154,6 +154,10 @@
   --page-version-menu-background: var(--color-smoke-70);
   --page-version-missing-font-color: var(--color-gray-30);
 
+  /* Breadcrumbs */
+  --breadcrumb-font-color: var(--body-font-light-color);
+  --breadcrumb-hover-font-color: var(--link_hover-font-color);
+
   /* Doc */
   --doc-font-color: var(--body-font-color);
   --doc-font-size: inherit;


### PR DESCRIPTION
Use a consistent color for both links and regular text and provide a little more margin from for the header.

Before:

![Screenshot 2024-03-13 at 11 43 32 AM](https://github.com/spring-io/antora-ui-spring/assets/519772/9685abb1-3a46-4cdb-9266-e4cca0b3c96c)

After:

![Screenshot 2024-03-13 at 11 46 50 AM](https://github.com/spring-io/antora-ui-spring/assets/519772/dea923ff-cf22-4442-81ae-c0ff65796ba5)
