### PR TITLE
fix: Uppercase XML tab label

### DIFF
--- a/src/css/vendor/asciidoctor-tabs.css
+++ b/src/css/vendor/asciidoctor-tabs.css
@@ -65,3 +65,7 @@
   border: 0;
   padding: 0;
 }
+
+.doc li.tab[data-sync-id="Xml"] {
+  text-transform: uppercase;
+}

--- a/src/css/vendor/spring-tabs.css
+++ b/src/css/vendor/spring-tabs.css
@@ -68,7 +68,3 @@
   padding: 1rem;
   background-color: var(--tabs-group-background-color);
 }
-
-.doc li.tab[data-sync-id="Xml"] {
-  text-transform: uppercase;
-}


### PR DESCRIPTION
Follow-up of #214, move the CSS rule to the right CSS file (asciidoctor-tabs.css).