### PR TITLE
Update Spring Tools menu

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -100,7 +100,7 @@
               href="https://spring.io/projects"
             >View all projects</a>
             <li class="navbar-item navbar-item-special-3">DEVELOPMENT TOOLS</li>
-            <a class="navbar-item" href="https://spring.io/tools">Spring Tools 4</a>
+            <a class="navbar-item" href="https://spring.io/tools">Spring Tools</a>
             <a
               class="navbar-item navbar-item-special-2"
               href="https://start.spring.io"


### PR DESCRIPTION
This commit updates Spring Tools menu to just "Spring Tools" without the version 4 as it has been done in other places in the website. cc @martinlippert